### PR TITLE
#157470274 Avail list of asset categories and the corresponding counts

### DIFF
--- a/api/models/asset_category.py
+++ b/api/models/asset_category.py
@@ -1,4 +1,7 @@
+from sqlalchemy.orm import column_property
+from sqlalchemy import select, func
 from .base.auditable_model import AuditableBaseModel
+from . import Asset
 from .database import db
 
 
@@ -17,3 +20,7 @@ class AssetCategory(AuditableBaseModel):
 
     def __repr__(self):
         return '<AssetCategory {}>'.format(self.name)
+
+
+AssetCategory.assets_count = column_property(select([func.count(Asset.id)])
+                                             .where(Asset.asset_category_id == AssetCategory.id))

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,1 +1,1 @@
-from .asset_category import AssetCategoryCount
+from .asset_category import AssetCategoryStats

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,5 +1,1 @@
-from flask import Blueprint
-from flask_restplus import Api
-
-api_bp = Blueprint('api', __name__)
-api = Api(api_bp)
+from .asset_category import AssetCategoryCount

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+from flask_restplus import Api
+
+api_bp = Blueprint('api', __name__)
+api = Api(api_bp)

--- a/api/views/asset_category.py
+++ b/api/views/asset_category.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, jsonify
+from flask_restplus import Resource
+
+from api.models import AssetCategory
+from . import api
+from api.middlewares.token_required import token_required
+
+# asset_category_bp = Blueprint('asset_category_bp', __name__)
+
+
+@api.route('/asset-categories/stats')
+class AssetCategoryCount(Resource):
+    """
+    Resource class for getting asset categories and
+    their corresponding asset counts
+    """
+
+    @token_required
+    def get(self):
+        asset_categories = AssetCategory._query().all()
+        data = []
+        for asset_category in asset_categories:
+            data.append({
+                'name': asset_category.name,
+                'asset_count': len(asset_category.assets)
+            })
+        return {
+            'message': 'Success',
+            'data': data
+        }

--- a/api/views/asset_category.py
+++ b/api/views/asset_category.py
@@ -1,7 +1,7 @@
 from flask_restplus import Resource
 
 from api.models import AssetCategory
-from . import api
+from main import api
 from api.middlewares.token_required import token_required
 
 
@@ -25,7 +25,7 @@ class AssetCategoryCount(Resource):
         for asset_category in asset_categories:
             data.append({
                 'name': asset_category.name,
-                'asset_count': len(asset_category.assets)
+                'asset_count': asset_category.assets_count
             })
         return {
             'message': 'Success',

--- a/api/views/asset_category.py
+++ b/api/views/asset_category.py
@@ -1,11 +1,8 @@
-from flask import Blueprint, jsonify
 from flask_restplus import Resource
 
 from api.models import AssetCategory
 from . import api
 from api.middlewares.token_required import token_required
-
-# asset_category_bp = Blueprint('asset_category_bp', __name__)
 
 
 @api.route('/asset-categories/stats')
@@ -17,6 +14,12 @@ class AssetCategoryCount(Resource):
 
     @token_required
     def get(self):
+        """
+        Get method for asset categories and corresponding asset count
+
+        :return: asset categories and counts
+        """
+
         asset_categories = AssetCategory._query().all()
         data = []
         for asset_category in asset_categories:

--- a/api/views/asset_category.py
+++ b/api/views/asset_category.py
@@ -6,7 +6,7 @@ from api.middlewares.token_required import token_required
 
 
 @api.route('/asset-categories/stats')
-class AssetCategoryCount(Resource):
+class AssetCategoryStats(Resource):
     """
     Resource class for getting asset categories and
     their corresponding asset counts
@@ -15,19 +15,18 @@ class AssetCategoryCount(Resource):
     @token_required
     def get(self):
         """
-        Get method for asset categories and corresponding asset count
-
-        :return: asset categories and counts
+        Gets asset categories and the corresponding asset count
         """
 
         asset_categories = AssetCategory._query().all()
         data = []
         for asset_category in asset_categories:
             data.append({
+                'id': asset_category.id,
                 'name': asset_category.name,
                 'asset_count': asset_category.assets_count
             })
         return {
-            'message': 'Success',
+            'status': 'success',
             'data': data
         }

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from api import api_blueprint
 
 from config import config
 from api.models.database import db
+from api.views import api_bp
 
 config_name = getenv('FLASK_ENV', default='production')
 
@@ -36,5 +37,7 @@ def create_app(config=config[config_name]):
 
     # initialize migration scripts
     migrate = Migrate(app, db)
+
+    app.register_blueprint(api_bp, url_prefix='/api/v1')
 
     return app

--- a/main.py
+++ b/main.py
@@ -34,6 +34,8 @@ def create_app(config=config[config_name]):
     # import all models
     from api.models import User, Asset, AssetCategory, Attribute
 
+    import api.views
+
     # initialize migration scripts
     migrate = Migrate(app, db)
 

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from api import api_blueprint
 
 from config import config
 from api.models.database import db
-from api.views import api_bp
 
 config_name = getenv('FLASK_ENV', default='production')
 
@@ -37,7 +36,5 @@ def create_app(config=config[config_name]):
 
     # initialize migration scripts
     migrate = Migrate(app, db)
-
-    app.register_blueprint(api_bp, url_prefix='/api/v1')
 
     return app

--- a/manage.py
+++ b/manage.py
@@ -7,8 +7,6 @@ from main import create_app
 from config import config
 
 from seeders import seed_asset_category
-import api.views
-
 
 # get flask config name from env or default to production config
 config_name = getenv('FLASK_ENV', default='production')

--- a/manage.py
+++ b/manage.py
@@ -7,6 +7,7 @@ from main import create_app
 from config import config
 
 from seeders import seed_asset_category
+import api.views
 
 
 # get flask config name from env or default to production config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from config import config
 from api.models.database import db as _db
 from api.models.user import User
 from api.models.asset_category import AssetCategory
-from api.models.asset import Asset
 
 config_name = 'testing'
 

--- a/tests/test_asset_categories_endpoints.py
+++ b/tests/test_asset_categories_endpoints.py
@@ -3,11 +3,15 @@ from flask import json
 
 
 class TestAssetCategoriesEndpoints:
-    def test_get_asset_count(self, client, init_db):
+    def test_asset_categories_stats_endpoint(self, client, new_asset_category, init_db):
+        new_asset_category.save()
         response = client.get('/api/v1/asset-categories/stats',
                               headers={'Authorization': getenv('TEST_TOKEN')})
         response_json = json.loads(response.data.decode('utf-8'))
 
         assert response.status_code == 200
-        assert response_json['message'] == 'Success'
+        assert response_json['status'] == 'success'
         assert isinstance(response_json['data'], list)
+        assert len(response_json['data']) is not 0
+        assert response_json['data'][0]['name'] == 'Laptop'
+        new_asset_category.delete()

--- a/tests/test_asset_categories_endpoints.py
+++ b/tests/test_asset_categories_endpoints.py
@@ -1,0 +1,13 @@
+from os import getenv
+from flask import json
+
+
+class TestAssetCategoriesEndpoints:
+    def test_get_asset_count(self, client, init_db):
+        response = client.get('/api/v1/asset-categories/stats',
+                              headers={'Authorization': getenv('TEST_TOKEN')})
+        response_json = json.loads(response.data.decode('utf-8'))
+
+        assert response.status_code == 200
+        assert response_json['message'] == 'Success'
+        assert isinstance(response_json['data'], list)


### PR DESCRIPTION
#### What does this PR do?
>- Adds functionality to get all asset categories and corresponding asset counts
#### Description of Task to be completed?
>- **Given** valid jwt-token credentials;
**When** the endpoint `GET /api/v1/asset-categories/stats` is invoked
**Then** return the list of asset-categories and the count of assets in them in the following format;
```
{
     status: 'success',
     data: [{
         id: -Id1
         name: 'Laptops',
         asset_count: 23
     },{
         id: -id2
         name: 'USB Dongles',
         asset_count: 23
     }]
}
```
#### How should this be manually tested?
>- Create a local branch `ft-create-models-157962202` and pull from origin
>- Create and activate a virtual environment by running the following in the root of the project:
     `python -m venv venv`
     `source venv/bin/activate`
>- Run `pip install -r requirements.txt` in your terminal
>- Start the application `python manage.py`
>- Send a GET request to this endpoint: `localhost:5000/api/v1/asset-categories/stats`
#### Any background context you want to provide?
>- N/A
#### What are the relevant pivotal tracker stories?
[#157470274](https://www.pivotaltracker.com/story/show/157470274)
#### Screenshots (if appropriate)
>- N/A
#### Questions:
>- N/A