### PR TITLE
157876086 Endpoint to delete asset-category

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,1 +1,1 @@
-FLASK_APP=manage
+FLASK_APP=manage.py

--- a/api/models/asset_category.py
+++ b/api/models/asset_category.py
@@ -29,3 +29,4 @@ class AssetCategory(AuditableBaseModel):
 AssetCategory.assets_count = column_property(
     select([func.count(Asset.id)])
     .where(Asset.asset_category_id == AssetCategory.id))
+

--- a/api/models/model_operations.py
+++ b/api/models/model_operations.py
@@ -53,6 +53,8 @@ class ModelOperations(object):
         relationships = self.get_child_relationships()
         if delete_validator(relationships):
             self.deleted = True
+            if request.decoded_token:
+                self.deleted_by = request.decoded_token['UserInfo']['name']
             db.session.add(self)
             db.session.commit()
         else:

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,1 +1,2 @@
 from .asset_category import AssetCategoryStats
+from api.views.asset_category import AssetCategoryResource

--- a/api/views/asset_category.py
+++ b/api/views/asset_category.py
@@ -83,6 +83,17 @@ class AssetCategoryStats(Resource):
             'data': data
         }
 
+    #         @token_required
+    # def delete(self, id):
+    #     """
+    #     Soft delete asset categories
+
+    #  single_category.delete()
+
+    #     return {
+    #         'status': 'success',
+    #         'message': 'category deleted successfully'
+
 
 @api.route('/asset-categories/<string:id>')
 class AssetCategoryListResource(Resource):
@@ -111,3 +122,23 @@ class AssetCategoryListResource(Resource):
                 single_category.attributes).data
            }
         }, 200
+
+    @token_required
+    def delete(self, id):
+        """
+        Soft delete asset categories
+        """
+        if not validate_id(id):
+            raise ValidationError(dict(message='Invalid id'), 400)
+
+        single_category = AssetCategory.get(id)
+        if not single_category or single_category.deleted:
+            raise ValidationError(dict(
+                message='Asset category not found'), 404)
+
+        single_category.delete()
+
+        return {
+            'status': 'success',
+            'message': 'category deleted successfully'
+        }

--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ config_name = getenv('FLASK_ENV', default='production')
 
 api = Api(api_blueprint, doc=False)
 
-
 def initialize_errorhandlers(application):
     ''' Initialize error handlers '''
     application.register_blueprint(middleware_blueprint)
@@ -34,7 +33,6 @@ def create_app(config=config[config_name]):
 
     # import all models
     from api.models import User, Asset, AssetCategory, Attribute
-
     import api.views
 
     # initialize migration scripts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import os
 
 import pytest
+from flask import current_app, request
 
 from main import create_app
 from config import config
@@ -86,7 +87,8 @@ def new_asset_category_with_non_deleted_asset(app):
 
 
 @pytest.fixture(scope='module')
-def new_asset_category_with_deleted_asset(app):
+def new_asset_category_with_deleted_asset(app, request_ctx,
+                                          mock_request_obj_decoded_token):
     """Fixture for asset category with a deleted child asset."""
     asset_category = AssetCategory(name='Laptop')
     asset_category = asset_category.save()
@@ -115,3 +117,31 @@ def auth_header(generate_token=generate_token):
         'Accept': MIMETYPE
 
     }
+
+
+@pytest.fixture(scope='module')
+def request_ctx():
+    """
+    Setup a request client, this gets executed for each test module.
+
+    :param app: Pytest fixture
+    :return: Flask request client
+    """
+    ctx = current_app.test_request_context()
+    ctx.push()
+    yield ctx
+    ctx.pop()
+
+
+@pytest.fixture(scope='module')
+def mock_request_obj_decoded_token():
+    """
+    Mock decoded_token from request object
+    """
+    decoded_token = setattr(request, 'decoded_token', {
+        'UserInfo': {
+            'name': 'Ayobami'
+        }
+    })
+
+    return decoded_token

--- a/tests/helpers/generate_token.py
+++ b/tests/helpers/generate_token.py
@@ -21,7 +21,7 @@ def generate_token(exp=None):
     """
 
     secret_key = getenv('JWT_SECRET_KEY')
-    payload = {'userInfo': user_one.to_dict()}
+    payload = {'UserInfo': user_one.to_dict()}
     payload.__setitem__('exp', exp) if exp is not None else ''
     token = jwt.encode(payload, secret_key, algorithm='RS256').decode(CHARSET)
     return 'Bearer {0}'.format(token)

--- a/tests/mocks/user.py
+++ b/tests/mocks/user.py
@@ -23,6 +23,7 @@ class User:
         return {
             'id': self.id,
             'email': self.email,
+            'name': self.name,
             'first_name': self.first_name,
             'last_name': self.last_name,
             'picture': self.picture,

--- a/tests/test_asset_categories_endpoints.py
+++ b/tests/test_asset_categories_endpoints.py
@@ -1,4 +1,5 @@
 "Module for asset category endpoint test"
+import pytest
 
 from os import getenv
 
@@ -22,7 +23,8 @@ class TestAssetCategoriesEndpoints:
     """
 
     def test_asset_categories_stats_endpoint(self, client, new_asset_category,
-                                             init_db, auth_header):
+                                             init_db, auth_header, request_ctx,
+                                             mock_request_obj_decoded_token):
         """
         Should pass when getting asset categories stats
         """
@@ -112,6 +114,12 @@ class TestAssetCategoriesEndpoints:
         assert response.status_code == 422
         assert response_json['status'] == 'error'
         assert response_json['errors']['0']['label'][0] == serialization_errors['field_required']  # noqa
+
+        #   def test_delete_asset_category(self, client, init_db, auth_header):
+        # """
+        #  Tests that a single asset category can be deleted
+
+
     def test_get_one_asset_category(self, client, init_db, auth_header):
         """
         Tests that a single asset category can be retrieved
@@ -155,6 +163,51 @@ class TestAssetCategoriesEndpoints:
 
         response = client.get('{}/asset-categories/L@@'.format(api_v1_base_url),
                               headers=auth_header)
+
+        response_json = json.loads(response.data.decode(CHARSET))
+        assert response.status_code == 400
+        assert response_json['status'] == 'error'
+        assert response_json['message'] == 'Invalid id'
+
+    def test_delete_asset_category(self, client, init_db, auth_header):
+        """
+            Tests that a single asset category can be deleted
+        """
+        asset_category = AssetCategory(name='TestLaptop')
+        asset_category.save()
+
+        response = client.delete('{}/asset-categories/{}'.format(
+            api_v1_base_url, asset_category.id), headers=auth_header)
+
+        response_json = json.loads(response.data.decode(CHARSET))
+
+        assert response.status_code == 200
+        assert response_json['status'] == 'success'
+
+    def test_delete_asset_category_not_found(self, client, init_db,
+                                             auth_header):
+        """
+            Tests that 404 is returned for a category that does not exist on
+            delete
+        """
+
+        response = client.delete('{}/asset-categories/-L2'.format(
+            api_v1_base_url), headers=auth_header)
+        response_json = json.loads(response.data.decode(CHARSET))
+        assert response.status_code == 404
+        assert response_json['status'] == 'error'
+        assert response_json['message'] == 'Asset category not found'
+
+    def test_delete_asset_category_invalid_id(self, client, init_db,
+                                              auth_header):
+        """
+        Tests that 400 is returned when id is invalid
+        """
+        asset_category = AssetCategory(name='TestLaptop')
+        asset_category.save()
+
+        response = client.delete('{}/asset-categories/LX@'.format(
+            api_v1_base_url), headers=auth_header)
 
         response_json = json.loads(response.data.decode(CHARSET))
         assert response.status_code == 400

--- a/tests/test_asset_model.py
+++ b/tests/test_asset_model.py
@@ -27,5 +27,6 @@ class TestAssetModel:
         asset.save()
         assert Asset.get(asset.id) == asset
 
-    def test_delete(self, new_asset_category):
+    def test_delete(self, new_asset_category, request_ctx,
+                    mock_request_obj_decoded_token):
         new_asset_category.assets[0].delete()

--- a/tests/test_attribute_model.py
+++ b/tests/test_attribute_model.py
@@ -37,5 +37,6 @@ class TestAttributeModel:
         attribute.save()
         assert Attribute.get(attribute.id) == attribute
 
-    def test_delete(self, new_asset_category):
+    def test_delete(self, new_asset_category, request_ctx,
+                    mock_request_obj_decoded_token):
         new_asset_category.attributes[0].delete()

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -24,6 +24,6 @@ class TestUserModel:
     assert user_query.filter(new_user.name == 'Ayobami').count() == 1
     assert isinstance(user_query.filter(new_user.name == 'Ayobami').all(), list)
 
-  def test_delete(self, new_user):
+  def test_delete(self, new_user, request_ctx, mock_request_obj_decoded_token):
     new_user.delete()
     

--- a/tests/test_validation_framework/test_delete_validator.py
+++ b/tests/test_validation_framework/test_delete_validator.py
@@ -8,13 +8,17 @@ from api.middlewares.base_validator import ValidationError
 class TestDeleteValidator(object):
     """Class to test model delete validator."""
 
-    def test_delete_model_with_no_child_relationships(self, new_user, init_db):
+    def test_delete_model_with_no_child_relationships(self, new_user, init_db,
+                                                      request_ctx,
+                                                      mock_request_obj_decoded_token):
         """Test delete on model with no children."""
         new_user.save()
         assert new_user.delete() is None
 
     def test_delete_model_with_child_relationships(self, init_db,
-                                                   new_asset_category):
+                                                   new_asset_category,
+                                                   request_ctx,
+                                                   mock_request_obj_decoded_token):
         """Test delete on model with children all deleted."""
         saved_category = new_asset_category.save()
         assert saved_category.delete() is None


### PR DESCRIPTION
#### What does this PR do?
delete asset categories

#### Description of Task to be completed?
* create an endpoint to delete asset categories
* write test for the asset category deletion

#### How should this be manually tested?
* clone the branch
* create a new virtual env
* run ``` pip install -r requrements.txt ```
* navigate to ```http://127.0.0.1:5000/api/v1/asset_categories/<string:id>``` on postman
* run ```pytest --setup-show``` to run the test

#### Any background context you want to provide?
* changed ```init_db``` function scope to ```module``` so the database will be dropped and recreated when every test module runs
* modify the delete method in ```model operations``` to implement a soft delete method

#### What are the relevant pivotal tracker stories?
#157876086 An endpoint to delete asset-category

#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-06-07 at 1 45 25 am" src="https://user-images.githubusercontent.com/24475008/41072325-ff01585e-69f4-11e8-845c-6cbbab6ace8b.png">
<img width="713" alt="screen shot 2018-06-07 at 1 45 59 am" src="https://user-images.githubusercontent.com/24475008/41072333-08e70044-69f5-11e8-84ca-36b4fafa73a2.png">


#### Questions:
N/A