### PR TITLE
#158183497 Move handle_exception error handler from base_validation module to main module

### DIFF
--- a/api/middlewares/base_validator.py
+++ b/api/middlewares/base_validator.py
@@ -1,7 +1,6 @@
 """Module for Validation error and error handler"""
 
 from flask import Blueprint, jsonify
-from main import api
 
 middleware_blueprint = Blueprint('middleware', __name__)
 
@@ -24,13 +23,3 @@ class ValidationError(Exception):
 
     def to_dict(self):
         return self.error
-
-
-@api.errorhandler(ValidationError)
-@middleware_blueprint.app_errorhandler(ValidationError)
-def handle_exception(error):
-    """Error handler called when a ValidationError Exception is raised"""
-
-    response = jsonify(error.to_dict())
-    response.status_code = error.status_code
-    return response

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 """Module for application factory."""
 from os import getenv
-from flask import Flask
+from flask import Flask, jsonify
 from flask_migrate import Migrate
 from flask_restplus import Api
 from api import api_blueprint
-
+from api.middlewares.base_validator import middleware_blueprint
+from api.middlewares.base_validator import ValidationError
 from config import config
 from api.models.database import db
 
@@ -15,7 +16,6 @@ api = Api(api_blueprint, doc=False)
 
 def initialize_errorhandlers(application):
     ''' Initialize error handlers '''
-    from api.middlewares.base_validator import middleware_blueprint
     application.register_blueprint(middleware_blueprint)
     application.register_blueprint(api_blueprint)
 
@@ -38,3 +38,13 @@ def create_app(config=config[config_name]):
     migrate = Migrate(app, db)
 
     return app
+
+
+@api.errorhandler(ValidationError)
+@middleware_blueprint.app_errorhandler(ValidationError)
+def handle_exception(error):
+    """Error handler called when a ValidationError Exception is raised"""
+
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response

--- a/main.py
+++ b/main.py
@@ -4,8 +4,9 @@ from flask import Flask, jsonify
 from flask_migrate import Migrate
 from flask_restplus import Api
 from api import api_blueprint
-from api.middlewares.base_validator import middleware_blueprint
-from api.middlewares.base_validator import ValidationError
+from api.middlewares.base_validator import (middleware_blueprint,
+                                            ValidationError)
+
 from config import config
 from api.models.database import db
 


### PR DESCRIPTION
#### What does this PR do?
move handle_exception error handler from base_validation module to main module

#### Description of Task to be completed?
Move `handle_exception` error handler  in the `base_validation` module to `main` module, import the `ValidationError` class into any models and a `circular import` error should not be thrown.
#### How should this be manually tested?
* clone the branch
* create a new virtual env
* run ``` pip install -r requrements.txt ```
*start the app with either `flask run` or `python manage.py runserver`, and no `circular import` error should be thrown


#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#158183497

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A