### PR TITLE
#158326441 Configure test coverage reporting for CodeClimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,19 +75,40 @@ jobs:
             # flask db init
             # flask db migrate
             flask db upgrade
+      - *cmd_download_cc_test_reporter
   run_tests:
     <<: *defaults
     steps:
       - checkout
+      - *cmd_attach_workspace
       - *cmd_install_dependencies
       - *cmd_save_cache
       - *cmd_wait_for_postgres
       - *cmd_restore_cache
+      - *cmd_download_cc_test_reporter
       - run:
           name: Run tests
           command: |
             . venv/bin/activate
-            pytest
+            pytest --cov=api/ tests --cov-report xml
+            /tmp/cc-test-reporter format-coverage coverage.xml -t "coverage.py" -o "tmp/cc.testreport.json"
+
+      - persist_to_workspace:
+          root: tmp/
+          paths:
+            - cc.testreport.json
+
+  upload_coverage:
+    <<: *defaults
+    steps:
+      - checkout
+      - *cmd_download_cc_test_reporter
+      - *cmd_attach_workspace
+      - run:
+          name: Upload coverage results to Code Climate
+          command: |
+            /tmp/cc-test-reporter upload-coverage -i tmp/cc.testreport.json
+
 
 workflows:
   version: 2
@@ -97,3 +118,6 @@ workflows:
       - run_tests:
           requires:
             - build
+      - upload_coverage:
+          requires:
+            - run_tests

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,6 @@
 ## Activo
+[![Maintainability](https://api.codeclimate.com/v1/badges/6594af3ff034d4737892/maintainability)](https://codeclimate.com/repos/5b16a8d8e4ba1a02d5001488/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/6594af3ff034d4737892/test_coverage)](https://codeclimate.com/repos/5b16a8d8e4ba1a02d5001488/test_coverage)
+
 An asset-management tool for Andela
 
 # Description 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ astroid==1.6.3
 attrs==18.1.0
 cffi==1.11.5
 click==6.7
+coverage==4.5.1
 cryptography==2.2.2
 Flask==1.0.2
 Flask-Migrate==2.1.1
@@ -31,6 +32,7 @@ pycparser==2.18
 PyJWT==1.4.2
 pylint==1.8.4
 pytest==3.5.1
+pytest-cov==2.5.1
 python-dateutil==2.7.3
 python-dotenv==0.8.2
 python-editor==1.0.3


### PR DESCRIPTION
#### What does this PR do?
This PR extends CircleCI configuration by adding test coverage reporting for CodeClimate.

#### Description of Task to be completed?
Configure test coverage reporting to CodeClimate after test are run. The coverage tools used are `pytest-cov` and `coverage.py`. They are set to generate a `coverage.xml` file of the test coverage report. This file is then formatted to JSON by the CodeClimate test coverage reporter and thereafter uploaded.

#### How should this be manually tested?
Once failing tests are fixed and this branch rebased, the CircleCI workflow should complete and the resulting coverage should be available on the CodeClimate overview page for this repo.
To test it locally, fetch this branch and run the following commands:
```bash
# To view coverage results on the terminal without creating a xml report file
pytest --cov=api/ tests

# To create a xml report file
pytest --cov=api/ tests --cov-report xml
```

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#158326441](https://www.pivotaltracker.com/story/show/158326441)


