### PR TITLE
#157767424 An endpoint to create asset category

### DIFF
--- a/api/utilities/messages/error_messages.py
+++ b/api/utilities/messages/error_messages.py
@@ -11,7 +11,6 @@ serialization_errors = {
     'string_characters': 'Field must start and end with a letter, only contain letters, non-consecutive fullstops, hyphens, spaces and apostrophes', #noqa
     'string_length': 'Field must be {0} characters or less'
 }
-
 jwt_errors = {
     'INVALID_TOKEN_MSG': "Authorization failed due to an Invalid token.",
     'EXPIRED_TOKEN_MSG': "Token expired. Please login to get a new token",
@@ -21,8 +20,6 @@ jwt_errors = {
     'NO_BEARER_MSG': "Bad request. The token should begin with the word 'Bearer'.", 
     'NO_TOKEN_MSG': "Bad request. Header does not contain an authorization token.",
 }
-
-
 database_errors = {
     'model_delete_children': 'Delete failed. The instance has relationship(s) with {0} not deleted.' #noqa
 }

--- a/api/views/asset_category.py
+++ b/api/views/asset_category.py
@@ -1,9 +1,58 @@
 from flask_restplus import Resource
-from flask import request
+from flask import request, jsonify
 
 from api.models import AssetCategory
 from main import api
 from api.middlewares.token_required import token_required
+from api.utilities.model_serializers.asset_category import AssetCategorySchema
+from api.utilities.model_serializers.attribute import AttributeSchema
+
+
+@api.route('/asset-categories')
+class AssetCategoryResource(Resource):
+    """
+    Resource class for peforming crud on the asset categories
+    """
+
+    @token_required
+    def post(self):
+        """
+        Creates asset categories and the corresponding attributes
+        """
+
+        request_data = request.get_json()
+
+        asset_category_schema = AssetCategorySchema()
+        asset_category = asset_category_schema.load_object_into_schema(
+            request_data)
+
+        attributes_data = request_data.get('attributes')
+        attributes = []
+
+        if attributes_data:
+            attributes_schema = AttributeSchema(many=True,
+                                                exclude=['id', 'deleted'])
+
+            attributes = attributes_schema.load_object_into_schema(
+                attributes_data)
+
+            asset_category.attributes = attributes
+            attributes = attributes_schema.dump(attributes).data
+
+        asset_category = asset_category.save()
+
+        response = jsonify({
+            "status": 'success',
+            "data": {
+                "name": asset_category.name,
+                "customAttributes": attributes
+            }
+        })
+
+        response.status_code = 201
+        return response
+
+
 
 
 @api.route('/asset-categories/stats')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,4 +80,3 @@ def auth_header(generate_token=generate_token):
         'Accept': MIMETYPE
 
     }
-

--- a/tests/mocks/asset_category.py
+++ b/tests/mocks/asset_category.py
@@ -1,0 +1,33 @@
+"Module for asset category request data"
+
+valid_asset_category_data = {
+    "name": "Headset",
+    "attributes": [
+        {
+            "label": "brand", "is_required": True,
+            "input_control": "text", "choices": "null"
+        },
+        {
+            "label": "color", "is_required": True,
+            "input_control": "dropdown", "choices": "blue,red,black"
+        }
+    ]
+}
+
+valid_asset_category_data_without_attributes = {
+    "name": "Headset"
+}
+
+invalid_asset_category_data = {
+    "name": "Headset",
+    "attributes": [
+        {
+            "labe": "brand", "is_required": True,
+            "input_control": "text", "choices": "null"
+        },
+        {
+            "label": "color", "is_required": True,
+            "input_control": "dropdown", "choices": "blue,red,black"
+        }
+    ]
+}

--- a/tests/test_asset_categories_endpoints.py
+++ b/tests/test_asset_categories_endpoints.py
@@ -1,14 +1,31 @@
+"Module for asset category endpoint test"
+
 from os import getenv
 
 from flask import json
 
 from api.utilities.constants import CHARSET
+from .mocks.asset_category import (
+    valid_asset_category_data,
+    invalid_asset_category_data,
+    valid_asset_category_data_without_attributes
+)
+from api.utilities.messages.error_messages import serialization_errors
 
 api_v1_base_url = getenv('API_BASE_URL_V1')
 
 
 class TestAssetCategoriesEndpoints:
-    def test_asset_categories_stats_endpoint(self, client, new_asset_category, init_db, auth_header):
+    """"
+    Asset Category endpoints test
+    """
+
+    def test_asset_categories_stats_endpoint(self, client, new_asset_category,
+                                             init_db, auth_header):
+        """
+        Should pass when getting asset categories stats
+        """
+        
         new_asset_category.save()
         response = client.get(f'{api_v1_base_url}/asset-categories/stats',
                               headers=auth_header)
@@ -19,3 +36,78 @@ class TestAssetCategoriesEndpoints:
         assert len(response_json['data']) is not 0
         assert response_json['data'][0]['name'] == 'Laptop'
         new_asset_category.delete()
+
+    def test_create_asset_categories_endpoint_with_valid_data(self, client,
+                                                              new_asset_category,  # noqa
+                                                              init_db,
+                                                              auth_header):
+        """
+        Should pass when valid data is provided
+        """
+
+        data = json.dumps(valid_asset_category_data)
+        response = client.post(
+            f'{api_v1_base_url}/asset-categories', data=data,
+            headers=auth_header
+        )
+        response_json = json.loads(response.data.decode(CHARSET))
+        assert response.status_code == 201
+        assert response_json['data']['name'] == valid_asset_category_data['name']  # noqa
+        assert response_json['data']['customAttributes'] == valid_asset_category_data['attributes']  # noqa
+        assert response_json['status'] == 'success'
+
+    def test_create_asset_categories_endpoint_with_valid_data_without_attributes(self, client, new_asset_category, init_db, auth_header):  # noqa
+        """
+        Should pass when valid data without attributes is provided
+        """
+
+        data = json.dumps(valid_asset_category_data_without_attributes)
+        response = client.post(
+            f'{api_v1_base_url}/asset-categories', data=data,
+            headers=auth_header
+        )
+        response_json = json.loads(response.data.decode(CHARSET))
+        assert response.status_code == 201
+        assert response_json['data']['name'] == valid_asset_category_data_without_attributes['name']  # noqa
+        assert response_json['data']['customAttributes'] == []
+        assert response_json['status'] == 'success'
+        
+    def test_create_asset_categories_endpoint_without_asset_category_name(self,
+                                                                          client,  # noqa
+                                                                          new_asset_category,  # noqa
+                                                                          init_db,  # noqa
+                                                                        auth_header):  # noqa
+        """
+        Should fail when asset category name is not data is provided
+        """
+        
+        data = json.dumps({})
+        response = client.post(
+            f'{api_v1_base_url}/asset-categories', data=data,
+            headers=auth_header
+        )
+
+        response_json = json.loads(response.data.decode(CHARSET))
+        assert response.status_code == 422
+        assert response_json['status'] == 'error'
+        assert response_json['errors']['name'][0] == serialization_errors['field_required']  # noqa
+    
+    def test_create_asset_categories_endpoint_with_invalid_attributes_data(self,  # noqa
+                                                                           client,  # noqa
+                                                                           new_asset_category,  # noqa
+                                                                           init_db,  # noqa
+                                                                        auth_header):  # noqa
+        """
+        Should fail when invalid attributes data is provided
+        """
+        
+        data = json.dumps(invalid_asset_category_data)
+        response = client.post(
+            f'{api_v1_base_url}/asset-categories', data=data,
+            headers=auth_header
+        )
+
+        response_json = json.loads(response.data.decode(CHARSET))
+        assert response.status_code == 422
+        assert response_json['status'] == 'error'
+        assert response_json['errors']['0']['label'][0] == serialization_errors['field_required']  # noqa


### PR DESCRIPTION
#### What does this PR do?
>- Creates asset categories
#### Description of Task to be completed?
>- As a developer, I should be able to create an asset category by passing the attributes of the asset category to /asset-categories
#### How should this be manually tested?
>- Create a local branch `ft-create-asset-category-157767424` and pull from origin
>- Start the application `flask run`
>- Send a POST request to this endpoint: `localhost:5000/api/v1/asset-categories`
with this data
 `{
	"name": "Headset",
	"attributes": [
              {"label": "brand", "is_required": "true", "input_control": "text", "choices": "null"}, 
              {"label": "color", "is_required": "true", "input_control": "dropdown", "choices": "blue,red,black"}
         ]
}` and an asset category should be created
>- To get errors remove the `Authorization` header or tamper with the request data
#### Any background context you want to provide?
>- N/A
#### What are the relevant pivotal tracker stories?
>- [#157767424](https://www.pivotaltracker.com/n/projects/2170023/stories/157767424)
#### Screenshots (if appropriate)
>- N/A
#### Questions:
>- N/A